### PR TITLE
tag.yml: fix version.py quote style to match ruff format

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -15,7 +15,8 @@ jobs:
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - name: versioning
-      run: "echo \"VERSION = '${GITHUB_REF##*/v}'\" > pstyle/version.py"
+      run: |
+        echo "VERSION = \"${GITHUB_REF##*/v}\"" > pstyle/version.py
     - uses: wtnb75/actions/python@v1
       with:
         extra-args: "--extra drivers"


### PR DESCRIPTION
## Background
Pushing the real `v0.2.1` tag just failed: https://github.com/wtnb75/pstyle/actions/runs/30812491400

`tag.yml`'s `versioning` step writes `pstyle/version.py` as:
```
VERSION = '0.2.1'
```
(single-quoted). The very next step, `wtnb75/actions/ruff@v1`, runs `ruff format --check --diff`, which defaults to double-quoted strings and immediately fails on the file the versioning step just generated:
```
1 file would be reformatted, 9 files already formatted
--- pstyle/version.py
+++ pstyle/version.py
@@ -1 +1 @@
-VERSION = '0.2.1'
+VERSION = "0.2.1"
```
This is the shared `versioning` step pattern used by every Python repo with a `tag.yml` in this fleet — this is the first time a real tag exercised it end-to-end.

## Fix
Generate the version string with double quotes instead, matching ruff's default style:
```yaml
- name: versioning
  run: |
    echo "VERSION = \"${GITHUB_REF##*/v}\"" > pstyle/version.py
```

## Verification
Reproduced the exact failing command locally:
```
$ GITHUB_REF="refs/tags/v0.2.1"
$ echo "VERSION = \"${GITHUB_REF##*/v}\"" > version_test.py
$ cat version_test.py
VERSION = "0.2.1"
$ ruff format --check --diff version_test.py
1 file already formatted
```
The `tag` workflow can only be exercised by an actual tag push, so full end-to-end verification needs a real tag once this merges. Since v0.2.1 already exists pointing at the old (broken) commit, it'll need to be moved/recreated after this merges to pick up the fix — that's a tag-history change, left for you to do.

## Note
The same `versioning` step pattern (single-quoted `echo`) is used by ~20 other Python repos in this fleet with a `tag.yml`. I'd like to sweep them too before any of them hits this for real — let me know if you want that done now.